### PR TITLE
feat/RSS-ECOMM-2_14 Set default addreses

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -100,5 +100,6 @@ module.exports = {
     'unused-imports/no-unused-imports': 'error',
     'import/prefer-default-export': 'off',
     'class-methods-use-this': 'off',
+    'react/require-default-props': 'off'
   }
 };

--- a/src/core/validation/user-registration.validation.schema.ts
+++ b/src/core/validation/user-registration.validation.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import dayjs, { Dayjs } from 'dayjs';
 import { getCountryLabelByCode } from '@constants/countries.const';
+import { Address } from '@models/index';
 import { loginFormSchema } from './user-login.validation.schema';
 
 interface PostalValidationRegEx {
@@ -15,6 +16,87 @@ export const postalValidationRegEx: PostalValidationRegEx = {
 };
 
 const MIN_AGE = 13;
+
+export const SHIPPING_ADDRESS_IDX = 0;
+export const BILLING_ADDRESS_IDX = 1;
+
+const addressSchema = z.object({
+  country: z.string(),
+  city: z.string(),
+  street: z.string(),
+  postalCode: z.string(),
+  isDefault: z.boolean(),
+});
+
+const validatePostalCode = (addresses: Address[], index: number, context: z.RefinementCtx) => {
+  const address = addresses[index];
+  if (!z.string().min(1).safeParse(address.postalCode).success) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Please provide postal code',
+      path: ['addresses', index, 'postalCode'],
+    });
+  } else {
+    const postalCodeTestReg = new RegExp(postalValidationRegEx[address.country]);
+    if (!postalCodeTestReg.test(address.postalCode)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid post code for country: ${getCountryLabelByCode(address.country)}`,
+        path: ['addresses', index, 'postalCode'],
+      });
+    }
+  }
+};
+
+const validateCity = (addresses: Address[], index: number, context: z.RefinementCtx) => {
+  const address = addresses[index];
+  if (!z.string().min(1).safeParse(address.city).success) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'City is required',
+      path: ['addresses', index, 'city'],
+    });
+  } else if (
+    !z
+      .string()
+      .regex(/^[a-zA-Z\s]+$/)
+      .safeParse(address.city).success
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Name of the city should n"t contains numbers or special symbols',
+      path: ['addresses', index, 'city'],
+    });
+  }
+};
+
+const validateAddress = (addresses: Address[], index: number, context: z.RefinementCtx) => {
+  const address = addresses[index];
+
+  if (!address) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Address is required`,
+      path: ['addresses', index, 'country'],
+    });
+  }
+  if (!z.string().min(1).safeParse(address.country).success) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Country is required',
+      path: ['addresses', index, 'country'],
+    });
+  }
+  validateCity(addresses, index, context);
+  if (!z.string().min(1).safeParse(address.street).success) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Street is required',
+      path: ['addresses', index, 'street'],
+    });
+  }
+  validatePostalCode(addresses, index, context);
+};
 
 const validateBirthDay = (dateString: string) => {
   const validDate = dayjs().subtract(MIN_AGE, 'year');
@@ -35,28 +117,13 @@ export const registrationSchema = z
         message: 'User should be older than 13 y.o.',
       })
       .transform((value: Dayjs) => value.toISOString()),
-    addresses: z.array(
-      z
-        .object({
-          street: z.string().min(1, 'Street is required'),
-          city: z
-            .string()
-            .min(1, 'City is required')
-            .regex(/^[a-zA-Z\s]+$/, 'Name of the city should n"t contains numbers or special symbols'),
-          country: z.string().min(1, 'Please select the country is required'),
-          postalCode: z.string().min(1, 'Please provide postal code'),
-          isDefault: z.boolean({ required_error: 'You have to decide is address default' }),
-        })
-        .superRefine((formValues, context) => {
-          const postalCodeTestReg = new RegExp(postalValidationRegEx[formValues.country]);
-          if (!postalCodeTestReg.test(formValues.postalCode)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `Invalid post code for country: ${getCountryLabelByCode(formValues.country)}`,
-              path: ['postalCode'],
-            });
-          }
-        }),
-    ),
+    shippingAsBilling: z.boolean(),
+    addresses: z.array(addressSchema),
   })
-  .merge(loginFormSchema);
+  .merge(loginFormSchema)
+  .superRefine((formValues, context) => {
+    validateAddress(formValues.addresses, SHIPPING_ADDRESS_IDX, context);
+    if (!formValues.shippingAsBilling) {
+      validateAddress(formValues.addresses, BILLING_ADDRESS_IDX, context);
+    }
+  });

--- a/src/core/validation/user-registration.validation.schema.ts
+++ b/src/core/validation/user-registration.validation.schema.ts
@@ -29,7 +29,7 @@ export const registrationSchema = z
     lastName: z.string().min(1, 'Last name is required'),
     birthDate: z
       .custom<Dayjs>()
-      .refine((value) => (value ? true : false), {
+      .refine((value) => !!value, {
         message: 'Birth day is required',
       })
       .refine((value) => (dayjs.isDayjs(value) && value.isValid() ? validateBirthDay(value.toISOString()) : false), {
@@ -43,7 +43,7 @@ export const registrationSchema = z
           city: z
             .string()
             .min(1, 'City is required')
-            .regex(/^[a-zA-Z]+$/, 'Name of the city should n"t contains numbers or special symbols'),
+            .regex(/^[a-zA-Z\s]+$/, 'Name of the city should n"t contains numbers or special symbols'),
           country: z.string().min(1, 'Please select the country is required'),
           postalCode: z.string().min(1, 'Please provide postal code'),
         })

--- a/src/core/validation/user-registration.validation.schema.ts
+++ b/src/core/validation/user-registration.validation.schema.ts
@@ -17,7 +17,6 @@ export const postalValidationRegEx: PostalValidationRegEx = {
 const MIN_AGE = 13;
 
 const validateBirthDay = (dateString: string) => {
-  console.log(dateString);
   const validDate = dayjs().subtract(MIN_AGE, 'year');
   const inputDate = dayjs(dateString);
   return inputDate.isSame(validDate, 'days') || inputDate.isBefore(validDate, 'days');

--- a/src/core/validation/user-registration.validation.schema.ts
+++ b/src/core/validation/user-registration.validation.schema.ts
@@ -17,6 +17,7 @@ export const postalValidationRegEx: PostalValidationRegEx = {
 const MIN_AGE = 13;
 
 const validateBirthDay = (dateString: string) => {
+  console.log(dateString);
   const validDate = dayjs().subtract(MIN_AGE, 'year');
   const inputDate = dayjs(dateString);
   return inputDate.isSame(validDate, 'days') || inputDate.isBefore(validDate, 'days');
@@ -28,6 +29,9 @@ export const registrationSchema = z
     lastName: z.string().min(1, 'Last name is required'),
     birthDate: z
       .custom<Dayjs>()
+      .refine((value) => (value ? true : false), {
+        message: 'Birth day is required',
+      })
       .refine((value) => (dayjs.isDayjs(value) && value.isValid() ? validateBirthDay(value.toISOString()) : false), {
         message: 'User should be older than 13 y.o.',
       })
@@ -35,12 +39,13 @@ export const registrationSchema = z
     addresses: z.array(
       z
         .object({
-          street: z.string({ required_error: 'Street is required' }),
+          street: z.string().min(1, 'Street is required'),
           city: z
-            .string({ required_error: 'City is required' })
+            .string()
+            .min(1, 'City is required')
             .regex(/^[a-zA-Z]+$/, 'Name of the city should n"t contains numbers or special symbols'),
-          country: z.string({ required_error: 'Please select country' }),
-          postalCode: z.string({ required_error: 'Please provide postal code' }),
+          country: z.string().min(1, 'Please select the country is required'),
+          postalCode: z.string().min(1, 'Please provide postal code'),
         })
         .superRefine((formValues, context) => {
           const postalCodeTestReg = new RegExp(postalValidationRegEx[formValues.country]);

--- a/src/core/validation/user-registration.validation.schema.ts
+++ b/src/core/validation/user-registration.validation.schema.ts
@@ -29,8 +29,8 @@ export const registrationSchema = z
     lastName: z.string().min(1, 'Last name is required'),
     birthDate: z
       .custom<Dayjs>()
-      .refine((value) => !!value, {
-        message: 'Birth day is required',
+      .refine((value) => dayjs.isDayjs(value) && value.isValid(), {
+        message: 'Please provide correct birth date',
       })
       .refine((value) => (dayjs.isDayjs(value) && value.isValid() ? validateBirthDay(value.toISOString()) : false), {
         message: 'User should be older than 13 y.o.',
@@ -46,6 +46,7 @@ export const registrationSchema = z
             .regex(/^[a-zA-Z\s]+$/, 'Name of the city should n"t contains numbers or special symbols'),
           country: z.string().min(1, 'Please select the country is required'),
           postalCode: z.string().min(1, 'Please provide postal code'),
+          isDefault: z.boolean({ required_error: 'You have to decide is address default' }),
         })
         .superRefine((formValues, context) => {
           const postalCodeTestReg = new RegExp(postalValidationRegEx[formValues.country]);

--- a/src/core/validation/user-registration.validation.test.ts
+++ b/src/core/validation/user-registration.validation.test.ts
@@ -1,20 +1,41 @@
 import '@testing-library/jest-dom';
 import { registrationSchema } from './user-registration.validation.schema';
+import dayjs from 'dayjs';
 
 test('first name should be provided', () => {
   const result = registrationSchema.safeParse({
     firstName: '',
     lastName: '',
     email: '',
-    addresses: [{ street: '', city: '', country: '', postalCode: '' }],
+    birthDate: '',
+    addresses: [{ street: 'Liberty', city: 'Kaz', country: 'Uzbekistan', postalCode: '22822' }],
   });
   expect(result.success).toBe(false);
+
   expect(result.error?.issues[0].message).toBe('First name is required');
   expect(result.error?.issues[1].message).toBe('Last name is required');
-  expect(result.error?.issues[3].message).toBe('Name of the city should n"t contains numbers or special symbols');
+  expect(result.error?.issues[2].message).toBe('Birth day is required');
+  expect(result.error?.issues[3].message).toBe('User should be older than 13 y.o.');
   expect(result.error?.issues[4].message).toBe('Email is required');
   expect(result.error?.issues[5].message).toBe('Email should contain symbol "@"');
   expect(result.error?.issues[6].message).toBe('Email should contain domain name');
   expect(result.error?.issues[7].message).toBe('Email should not contain whitespace');
   expect(result.error?.issues[8].message).toBe('Email address should be properly formatted (e.g., user@example.com)');
+});
+
+test('first name should be provided', () => {
+  const result = registrationSchema.safeParse({
+    firstName: 'f',
+    lastName: 'g',
+    birthDate: dayjs('1999-06-05T22:00:00.000Z'),
+    email: 'jaks134@mail.ru',
+    addresses: [{ street: '', city: '', country: '', postalCode: '' }],
+  });
+  expect(result.success).toBe(false);
+
+  expect(result.error?.issues[0].message).toBe('Street is required');
+  expect(result.error?.issues[1].message).toBe('City is required');
+  expect(result.error?.issues[2].message).toBe('Name of the city should n"t contains numbers or special symbols');
+  expect(result.error?.issues[3].message).toBe('Please select the country is required');
+  expect(result.error?.issues[4].message).toBe('Please provide postal code');
 });

--- a/src/core/validation/user-registration.validation.test.ts
+++ b/src/core/validation/user-registration.validation.test.ts
@@ -8,13 +8,13 @@ test('personal data should be provided', () => {
     lastName: '',
     email: '',
     birthDate: '',
-    addresses: [{ street: 'Liberty', city: 'Kaz', country: 'Uzbekistan', postalCode: '22822' }],
+    addresses: [{ street: 'Liberty', city: 'Kaz', country: 'Uzbekistan', postalCode: '22822', isDefault: false }],
   });
   expect(result.success).toBe(false);
 
   expect(result.error?.issues[0].message).toBe('First name is required');
   expect(result.error?.issues[1].message).toBe('Last name is required');
-  expect(result.error?.issues[2].message).toBe('Birth day is required');
+  expect(result.error?.issues[2].message).toBe('Please provide correct birth date');
   expect(result.error?.issues[3].message).toBe('User should be older than 13 y.o.');
   expect(result.error?.issues[4].message).toBe('Email is required');
   expect(result.error?.issues[5].message).toBe('Email should contain symbol "@"');
@@ -38,4 +38,5 @@ test('address data should be provided', () => {
   expect(result.error?.issues[2].message).toBe('Name of the city should n"t contains numbers or special symbols');
   expect(result.error?.issues[3].message).toBe('Please select the country is required');
   expect(result.error?.issues[4].message).toBe('Please provide postal code');
+  expect(result.error?.issues[5].message).toBe('You have to decide is address default');
 });

--- a/src/core/validation/user-registration.validation.test.ts
+++ b/src/core/validation/user-registration.validation.test.ts
@@ -2,45 +2,19 @@ import '@testing-library/jest-dom';
 import { registrationSchema } from './user-registration.validation.schema';
 
 test('first name should be provided', () => {
-  const result = registrationSchema.safeParse({});
+  const result = registrationSchema.safeParse({
+    firstName: '',
+    lastName: '',
+    email: '',
+    addresses: [{ street: '', city: '', country: '', postalCode: '' }],
+  });
   expect(result.success).toBe(false);
   expect(result.error?.issues[0].message).toBe('First name is required');
-});
-
-test('last name should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
   expect(result.error?.issues[1].message).toBe('Last name is required');
-});
-
-// TODO: divide date check for empty and older
-
-test('user birth date should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
-  expect(result.error?.issues[2].message).toBe('User should be older than 13 y.o.');
-});
-
-test('street should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
-  expect(result.error?.issues[3].message).toBe('Street is required');
-});
-
-test('city should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
-  expect(result.error?.issues[4].message).toBe('City is required');
-});
-
-test('country should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
-  expect(result.error?.issues[5].message).toBe('Please select country');
-});
-
-test('postal code should be provided', () => {
-  const result = registrationSchema.safeParse({});
-  expect(result.success).toBe(false);
-  expect(result.error?.issues[6].message).toBe('Please provide postal code');
+  expect(result.error?.issues[3].message).toBe('Name of the city should n"t contains numbers or special symbols');
+  expect(result.error?.issues[4].message).toBe('Email is required');
+  expect(result.error?.issues[5].message).toBe('Email should contain symbol "@"');
+  expect(result.error?.issues[6].message).toBe('Email should contain domain name');
+  expect(result.error?.issues[7].message).toBe('Email should not contain whitespace');
+  expect(result.error?.issues[8].message).toBe('Email address should be properly formatted (e.g., user@example.com)');
 });

--- a/src/core/validation/user-registration.validation.test.ts
+++ b/src/core/validation/user-registration.validation.test.ts
@@ -16,14 +16,14 @@ test('personal data should be provided', () => {
   expect(result.error?.issues[1].message).toBe('Last name is required');
   expect(result.error?.issues[2].message).toBe('Please provide correct birth date');
   expect(result.error?.issues[3].message).toBe('User should be older than 13 y.o.');
-  expect(result.error?.issues[4].message).toBe('Email is required');
-  expect(result.error?.issues[5].message).toBe('Email should contain symbol "@"');
-  expect(result.error?.issues[6].message).toBe('Email should contain domain name');
-  expect(result.error?.issues[7].message).toBe('Email should not contain whitespace');
-  expect(result.error?.issues[8].message).toBe(
+  expect(result.error?.issues[5].message).toBe('Email is required');
+  expect(result.error?.issues[6].message).toBe('Email should contain symbol "@"');
+  expect(result.error?.issues[7].message).toBe('Email should contain domain name');
+  expect(result.error?.issues[8].message).toBe('Email should not contain whitespace');
+  expect(result.error?.issues[9].message).toBe(
     'Email should contain only English letters, numbers, and special symbols',
   );
-  expect(result.error?.issues[9].message).toBe('Email address should be properly formatted (e.g., user@example.com)');
+  expect(result.error?.issues[10].message).toBe('Email address should be properly formatted (e.g., user@example.com)');
 });
 
 test('address data should be provided', () => {
@@ -31,15 +31,14 @@ test('address data should be provided', () => {
     firstName: 'f',
     lastName: 'g',
     birthDate: dayjs('1999-06-05T22:00:00.000Z'),
+    shippingAsBilling: true,
     email: 'jaks134@mail.ru',
-    addresses: [{ street: '', city: '', country: '', postalCode: '' }],
+    password: 'fjfD3&dl#sL',
+    addresses: [{ street: '', city: '', country: '', postalCode: '', isDefault: true }],
   });
   expect(result.success).toBe(false);
-
-  expect(result.error?.issues[0].message).toBe('Street is required');
+  expect(result.error?.issues[0].message).toBe('Country is required');
   expect(result.error?.issues[1].message).toBe('City is required');
-  expect(result.error?.issues[2].message).toBe('Name of the city should n"t contains numbers or special symbols');
-  expect(result.error?.issues[3].message).toBe('Please select the country is required');
-  expect(result.error?.issues[4].message).toBe('Please provide postal code');
-  expect(result.error?.issues[5].message).toBe('You have to decide is address default');
+  expect(result.error?.issues[2].message).toBe('Street is required');
+  expect(result.error?.issues[3].message).toBe('Please provide postal code');
 });

--- a/src/core/validation/user-registration.validation.test.ts
+++ b/src/core/validation/user-registration.validation.test.ts
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
-import { registrationSchema } from './user-registration.validation.schema';
 import dayjs from 'dayjs';
+import { registrationSchema } from './user-registration.validation.schema';
 
-test('first name should be provided', () => {
+test('personal data should be provided', () => {
   const result = registrationSchema.safeParse({
     firstName: '',
     lastName: '',
@@ -23,7 +23,7 @@ test('first name should be provided', () => {
   expect(result.error?.issues[8].message).toBe('Email address should be properly formatted (e.g., user@example.com)');
 });
 
-test('first name should be provided', () => {
+test('address data should be provided', () => {
   const result = registrationSchema.safeParse({
     firstName: 'f',
     lastName: 'g',

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ export type Address = {
   city: string;
   country: string;
   postalCode: string;
+  isDefault: boolean;
 };
 
 export type UserRegistrationData = {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,14 +3,18 @@ export type SelectOption = {
   label: string;
 };
 
+export type Address = {
+  street: string;
+  city: string;
+  country: string;
+  postalCode: string;
+};
+
 export type UserRegistrationData = {
   email: string;
   password: string;
   firstName: string;
   lastName: string;
   birthDate: string;
-  street: string;
-  city: string;
-  country: string;
-  postalCode: string;
+  addresses: Array<Address>;
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -16,5 +16,5 @@ export type UserRegistrationData = {
   firstName: string;
   lastName: string;
   birthDate: string;
-  addresses: Array<Address>;
+  addresses: Address[];
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,13 +10,3 @@ export type Address = {
   postalCode: string;
   isDefault: boolean;
 };
-
-export type UserRegistrationData = {
-  email: string;
-  password: string;
-  firstName: string;
-  lastName: string;
-  birthDate: string;
-  shippingAsBilling: boolean;
-  addresses: Address[];
-};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,5 +17,6 @@ export type UserRegistrationData = {
   firstName: string;
   lastName: string;
   birthDate: string;
+  shippingAsBilling: boolean;
   addresses: Address[];
 };

--- a/src/pages/Layout/Layout.page.tsx
+++ b/src/pages/Layout/Layout.page.tsx
@@ -18,7 +18,7 @@ const layoutStyles = {
     p: 0,
     width: { sm: `calc(100% - ${drawerWidth}px)` },
   },
-  main: { p: 3, display: 'flex', flexDirection: 'column', flexGrow: 1 },
+  main: { p: 3, display: 'flex', flexDirection: 'column', flexGrow: 1, overflow: 'auto' },
 };
 
 function LayoutPage() {

--- a/src/pages/Registration/Registration.page.test.tsx
+++ b/src/pages/Registration/Registration.page.test.tsx
@@ -4,6 +4,5 @@ import RegistrationPage from './Registration.page';
 
 test('Render the registration page', () => {
   render(<RegistrationPage />);
-
   expect(true).toBeTruthy();
 });

--- a/src/pages/Registration/Registration.page.tsx
+++ b/src/pages/Registration/Registration.page.tsx
@@ -9,7 +9,7 @@ function RegistrationPage(): ReactNode {
     return Promise.resolve('Ok');
   }, []);
   return (
-    <Stack>
+    <Stack direction="column" alignItems="center">
       <RegistrationForm onSubmit={handleFormSubmit} />
       <Typography marginTop={2}>
         Already have an account? <Link to="/login">Sign in</Link>

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -31,8 +31,8 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
         lastName: '',
         birthDate: '',
         addresses: [
-          { street: '', city: '', country: defaultCountryOption.id, postalCode: '' },
-          { street: '', city: '', country: defaultCountryOption.id, postalCode: '' },
+          { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
+          { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
         ],
       }}
       onSuccess={onSubmit}
@@ -57,8 +57,8 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
           <DatePickerElement<UserRegistrationData> name="birthDate" label="Birth Date" required helperText=" " />
         </LocalizationProvider>
         <Stack direction="row" gap={2}>
-          <UserAddress title="Billing address" addressIndex={0} />
-          <UserAddress title="Shipping address" addressIndex={1} />
+          <UserAddress title="billing address" addressIndex={0} />
+          <UserAddress title="shipping address" addressIndex={1} />
         </Stack>
         <Button type="submit" variant="contained" color="primary" sx={formStyles.submitButton}>
           Submit

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -48,8 +48,8 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
   const shippingAsBilling = useWatch<UserRegistrationData>({ control, name: 'shippingAsBilling' });
 
   return (
-    <FormContainer<UserRegistrationData> formContext={formContext} onSuccess={onSubmit} mode="onChange">
-      <Container maxWidth="md">
+    <Container maxWidth="md">
+      <FormContainer<UserRegistrationData> formContext={formContext} onSuccess={onSubmit} mode="onChange">
         <Typography variant="h4" gutterBottom>
           Sign up
         </Typography>
@@ -104,20 +104,20 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
               <CheckboxElement<UserRegistrationData> name="shippingAsBilling" label="Use as billing address" />
             </Grid>
           </Grid>
-          <Grid item xs={1}>
-            {!shippingAsBilling && (
+          {!shippingAsBilling && (
+            <Grid item xs={1}>
               <UserAddress
                 title="Billing address"
                 addressIndex={BILLING_ADDRESS_IDX}
                 onCountryChange={() => trigger(`addresses.${BILLING_ADDRESS_IDX}.postalCode`)}
               />
-            )}
-          </Grid>
+            </Grid>
+          )}
         </Grid>
         <Button type="submit" variant="contained" color="primary" sx={{ mx: 'auto' }}>
           Sign up
         </Button>
-      </Container>
-    </FormContainer>
+      </FormContainer>
+    </Container>
   );
 }

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -56,7 +56,7 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePickerElement<UserRegistrationData> name="birthDate" label="Birth Date" required helperText=" " />
         </LocalizationProvider>
-        <Stack direction={'row'} gap={2}>
+        <Stack direction="row" gap={2}>
           <UserAddress title="Billing address" addressIndex={0} />
           <UserAddress title="Shipping address" addressIndex={1} />
         </Stack>

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -5,36 +5,29 @@ import {
   DatePickerElement,
   useForm,
   CheckboxElement,
+  useWatch,
 } from 'react-hook-form-mui';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { UserRegistrationData } from '@models/index';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import { Button, Container, Grid, Typography } from '@mui/material';
+import {
+  BILLING_ADDRESS_IDX,
+  registrationSchema,
+  SHIPPING_ADDRESS_IDX,
+} from '@core/validation/user-registration.validation.schema';
+import { z } from 'zod';
 import { defaultCountryOption } from '@constants/countries.const';
-import { registrationSchema } from '@core/validation/user-registration.validation.schema';
 import { UserAddress } from './UserAddress';
 
-const formStyles = {
-  form: { display: 'flex', flexDirection: 'column', width: '100%', height: '100%' },
-  submitButton: { width: 100 },
-  textField: { minWidth: 410 },
-  divider: { height: '1px', backgroundColor: 'black' },
-};
+export type UserRegistrationData = z.infer<typeof registrationSchema>;
 
 export interface RegistrationFormProps {
   onSubmit: (registrationData: UserRegistrationData) => void;
 }
 
 export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
-  // const [isSameAddresses, setSameAddressValue] = useState(false);
-
-  // const handleSameAddressesSet = () => {
-  //   setSameAddressValue(!isSameAddresses);
-  // };
-
-  // const billingAddressForm = isSameAddresses ? null : <UserAddress title="Billing address" addressIndex={1} />;
   const formContext = useForm<UserRegistrationData>({
     defaultValues: {
       email: '',
@@ -51,37 +44,80 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
     resolver: zodResolver(registrationSchema),
   });
 
-  // const {formState :{}} = formContext;
+  const { control, trigger } = formContext;
+  const shippingAsBilling = useWatch<UserRegistrationData>({ control, name: 'shippingAsBilling' });
 
   return (
     <FormContainer<UserRegistrationData> formContext={formContext} onSuccess={onSubmit} mode="onChange">
-      <Box sx={formStyles.form}>
+      <Container maxWidth="md">
         <Typography variant="h4" gutterBottom>
           Sign up
         </Typography>
-        <TextFieldElement<UserRegistrationData> name="email" label="Email" required helperText=" " />
-        <PasswordElement<UserRegistrationData>
-          margin="dense"
-          label="Password"
-          required
-          name="password"
-          helperText=" "
-        />
-        <TextFieldElement<UserRegistrationData> name="firstName" label="First Name" required helperText=" " />
-        <TextFieldElement<UserRegistrationData> name="lastName" label="Last Name" required helperText=" " />
-
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <DatePickerElement<UserRegistrationData> name="birthDate" label="Birth Date" required helperText=" " />
-        </LocalizationProvider>
-        <Stack gap={2}>
-          <UserAddress title="Shipping address" addressIndex={0} />
-          <CheckboxElement<UserRegistrationData> name="shippingAsBilling" label="Also use as billing address" />
-          <UserAddress title="Billing address" addressIndex={1} />
-        </Stack>
-        <Button type="submit" variant="contained" color="primary" sx={formStyles.submitButton}>
+        <Grid container spacing={{ xs: 1, sm: 2 }} columns={{ xs: 1, md: 2 }}>
+          <Grid item xs={1}>
+            <TextFieldElement<UserRegistrationData> name="email" label="Email" required helperText=" " fullWidth />
+          </Grid>
+          <Grid item xs={1}>
+            <PasswordElement<UserRegistrationData> label="Password" required name="password" helperText=" " fullWidth />
+          </Grid>
+        </Grid>
+        <Grid container spacing={{ xs: 1, sm: 2 }} columns={{ xs: 1, md: 12 }}>
+          <Grid item xs={1} md={6}>
+            <TextFieldElement<UserRegistrationData>
+              name="firstName"
+              label="First Name"
+              required
+              helperText=" "
+              fullWidth
+            />
+          </Grid>
+          <Grid item xs={1} md={6}>
+            <TextFieldElement<UserRegistrationData>
+              name="lastName"
+              label="Last Name"
+              required
+              helperText=" "
+              fullWidth
+            />
+          </Grid>
+        </Grid>
+        <Grid item xs={1} md={4}>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <DatePickerElement<UserRegistrationData>
+              name="birthDate"
+              label="Birth Date"
+              required
+              helperText=" "
+              sx={{ maxWidth: 350, alignItem: 'start' }}
+            />
+          </LocalizationProvider>
+        </Grid>
+        <Grid container spacing={{ xs: 1, sm: 2 }} columns={{ xs: 1, md: 2 }}>
+          {/* eslint-disable-next-line no-magic-numbers */}
+          <Grid item xs={shippingAsBilling ? 2 : 1}>
+            <UserAddress
+              title="Shipping address"
+              addressIndex={SHIPPING_ADDRESS_IDX}
+              onCountryChange={() => trigger(`addresses.${SHIPPING_ADDRESS_IDX}.postalCode`)}
+            />
+            <Grid item>
+              <CheckboxElement<UserRegistrationData> name="shippingAsBilling" label="Use as billing address" />
+            </Grid>
+          </Grid>
+          <Grid item xs={1}>
+            {!shippingAsBilling && (
+              <UserAddress
+                title="Billing address"
+                addressIndex={BILLING_ADDRESS_IDX}
+                onCountryChange={() => trigger(`addresses.${BILLING_ADDRESS_IDX}.postalCode`)}
+              />
+            )}
+          </Grid>
+        </Grid>
+        <Button type="submit" variant="contained" color="primary" sx={{ mx: 'auto' }}>
           Sign up
         </Button>
-      </Box>
+      </Container>
     </FormContainer>
   );
 }

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -1,18 +1,13 @@
-import {
-  FormContainer,
-  TextFieldElement,
-  PasswordElement,
-  SelectElement,
-  DatePickerElement,
-} from 'react-hook-form-mui';
+import { FormContainer, TextFieldElement, PasswordElement, DatePickerElement } from 'react-hook-form-mui';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { UserRegistrationData } from '@models/index';
-import { Box, Button, Typography } from '@mui/material';
-import { countriesOptions, defaultCountryOption } from '@constants/countries.const';
+import { Box, Button, Stack, Typography } from '@mui/material';
+import { defaultCountryOption } from '@constants/countries.const';
 import { registrationSchema } from '@core/validation/user-registration.validation.schema';
+import { UserAddress } from './UserAddress';
 
 const formStyles = {
   form: { display: 'flex', flexDirection: 'column', width: '100%', height: '100%' },
@@ -35,10 +30,10 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
         firstName: '',
         lastName: '',
         birthDate: '',
-        street: '',
-        city: '',
-        country: defaultCountryOption.id,
-        postalCode: '',
+        addresses: [
+          { street: '', city: '', country: defaultCountryOption.id, postalCode: '' },
+          { street: '', city: '', country: defaultCountryOption.id, postalCode: '' },
+        ],
       }}
       onSuccess={onSubmit}
       mode="onChange"
@@ -61,19 +56,10 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePickerElement<UserRegistrationData> name="birthDate" label="Birth Date" required helperText=" " />
         </LocalizationProvider>
-        <Typography variant="h6" gutterBottom>
-          Pass your address
-        </Typography>
-        <SelectElement<UserRegistrationData>
-          label="Country"
-          name="country"
-          options={countriesOptions}
-          helperText=" "
-          required
-        />
-        <TextFieldElement<UserRegistrationData> name="postalCode" label="Postal Code" required helperText=" " />
-        <TextFieldElement<UserRegistrationData> name="city" label="City" required helperText=" " />
-        <TextFieldElement<UserRegistrationData> name="street" label="Street" required helperText=" " />
+        <Stack direction={'row'} gap={2}>
+          <UserAddress title="Billing address" addressIndex={0} />
+          <UserAddress title="Shipping address" addressIndex={1} />
+        </Stack>
         <Button type="submit" variant="contained" color="primary" sx={formStyles.submitButton}>
           Submit
         </Button>

--- a/src/pages/Registration/components/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm.tsx
@@ -1,4 +1,11 @@
-import { FormContainer, TextFieldElement, PasswordElement, DatePickerElement } from 'react-hook-form-mui';
+import {
+  FormContainer,
+  TextFieldElement,
+  PasswordElement,
+  DatePickerElement,
+  useForm,
+  CheckboxElement,
+} from 'react-hook-form-mui';
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -21,23 +28,33 @@ export interface RegistrationFormProps {
 }
 
 export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
+  // const [isSameAddresses, setSameAddressValue] = useState(false);
+
+  // const handleSameAddressesSet = () => {
+  //   setSameAddressValue(!isSameAddresses);
+  // };
+
+  // const billingAddressForm = isSameAddresses ? null : <UserAddress title="Billing address" addressIndex={1} />;
+  const formContext = useForm<UserRegistrationData>({
+    defaultValues: {
+      email: '',
+      password: '',
+      firstName: '',
+      lastName: '',
+      birthDate: '',
+      shippingAsBilling: false,
+      addresses: [
+        { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
+        { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
+      ],
+    },
+    resolver: zodResolver(registrationSchema),
+  });
+
+  // const {formState :{}} = formContext;
+
   return (
-    <FormContainer<UserRegistrationData>
-      resolver={zodResolver(registrationSchema)}
-      defaultValues={{
-        email: '',
-        password: '',
-        firstName: '',
-        lastName: '',
-        birthDate: '',
-        addresses: [
-          { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
-          { street: '', city: '', country: defaultCountryOption.id, postalCode: '', isDefault: false },
-        ],
-      }}
-      onSuccess={onSubmit}
-      mode="onChange"
-    >
+    <FormContainer<UserRegistrationData> formContext={formContext} onSuccess={onSubmit} mode="onChange">
       <Box sx={formStyles.form}>
         <Typography variant="h4" gutterBottom>
           Sign up
@@ -56,9 +73,10 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePickerElement<UserRegistrationData> name="birthDate" label="Birth Date" required helperText=" " />
         </LocalizationProvider>
-        <Stack direction="row" gap={2}>
-          <UserAddress title="billing address" addressIndex={0} />
-          <UserAddress title="shipping address" addressIndex={1} />
+        <Stack gap={2}>
+          <UserAddress title="Shipping address" addressIndex={0} />
+          <CheckboxElement<UserRegistrationData> name="shippingAsBilling" label="Also use as billing address" />
+          <UserAddress title="Billing address" addressIndex={1} />
         </Stack>
         <Button type="submit" variant="contained" color="primary" sx={formStyles.submitButton}>
           Sign up

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -8,7 +8,7 @@ export interface UserAddressProps {
   addressIndex: number;
 }
 
-export const UserAddress = ({ title, addressIndex }: UserAddressProps) => {
+export function UserAddress({ title, addressIndex }: UserAddressProps) {
   return (
     <Stack>
       <Typography variant="h6" gutterBottom>
@@ -41,4 +41,4 @@ export const UserAddress = ({ title, addressIndex }: UserAddressProps) => {
       />
     </Stack>
   );
-};
+}

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -1,6 +1,6 @@
 import { countriesOptions } from '@constants/countries.const';
 import { UserRegistrationData } from '@models/index';
-import { Checkbox, FormControlLabel, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { SelectElement, SwitchElement, TextFieldElement } from 'react-hook-form-mui';
 
 export interface UserAddressProps {

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -39,10 +39,7 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         required
         helperText=" "
       />
-      <CheckboxElement<UserRegistrationData>
-        label={`set as default ${title.split(' ')[0]} address`}
-        name={`addresses.${addressIndex}.isDefault`}
-      />
+      <CheckboxElement<UserRegistrationData> label={`set as default`} name={`addresses.${addressIndex}.isDefault`} />
     </Stack>
   );
 }

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -39,7 +39,7 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         required
         helperText=" "
       />
-      <CheckboxElement<UserRegistrationData> label={`set as default`} name={`addresses.${addressIndex}.isDefault`} />
+      <CheckboxElement<UserRegistrationData> label="set as default" name={`addresses.${addressIndex}.isDefault`} />
     </Stack>
   );
 }

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -1,7 +1,7 @@
 import { countriesOptions } from '@constants/countries.const';
 import { UserRegistrationData } from '@models/index';
-import { Stack, Typography } from '@mui/material';
-import { CheckboxElement, SelectElement, TextFieldElement } from 'react-hook-form-mui';
+import { Checkbox, FormControlLabel, Stack, Typography } from '@mui/material';
+import { SelectElement, SwitchElement, TextFieldElement } from 'react-hook-form-mui';
 
 export interface UserAddressProps {
   title: string;
@@ -39,7 +39,8 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         required
         helperText=" "
       />
-      <CheckboxElement<UserRegistrationData> label="set as default" name={`addresses.${addressIndex}.isDefault`} />
+      <SwitchElement<UserRegistrationData> label="set as default" name={`addresses.${addressIndex}.isDefault`} />
+      {/* {AsBillingButton} */}
     </Stack>
   );
 }

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -1,7 +1,7 @@
 import { countriesOptions } from '@constants/countries.const';
 import { UserRegistrationData } from '@models/index';
 import { Stack, Typography } from '@mui/material';
-import { SelectElement, TextFieldElement } from 'react-hook-form-mui';
+import { CheckboxElement, SelectElement, TextFieldElement } from 'react-hook-form-mui';
 
 export interface UserAddressProps {
   title: string;
@@ -38,6 +38,10 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         label="Street"
         required
         helperText=" "
+      />
+      <CheckboxElement<UserRegistrationData>
+        label={`set as default ${title.split(' ')[0]} address`}
+        name={`addresses.${addressIndex}.isDefault`}
       />
     </Stack>
   );

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -1,0 +1,44 @@
+import { countriesOptions } from '@constants/countries.const';
+import { UserRegistrationData } from '@models/index';
+import { Stack, Typography } from '@mui/material';
+import { SelectElement, TextFieldElement } from 'react-hook-form-mui';
+
+export interface UserAddressProps {
+  title: string;
+  addressIndex: number;
+}
+
+export const UserAddress = ({ title, addressIndex }: UserAddressProps) => {
+  return (
+    <Stack>
+      <Typography variant="h6" gutterBottom>
+        {title}
+      </Typography>
+      <SelectElement<UserRegistrationData>
+        label="Country"
+        name={`addresses.${addressIndex}.country`}
+        options={countriesOptions}
+        helperText=" "
+        required
+      />
+      <TextFieldElement<UserRegistrationData>
+        name={`addresses.${addressIndex}.postalCode`}
+        label="Postal Code"
+        required
+        helperText=" "
+      />
+      <TextFieldElement<UserRegistrationData>
+        name={`addresses.${addressIndex}.city`}
+        label="City"
+        required
+        helperText=" "
+      />
+      <TextFieldElement<UserRegistrationData>
+        name={`addresses.${addressIndex}.street`}
+        label="Street"
+        required
+        helperText=" "
+      />
+    </Stack>
+  );
+};

--- a/src/pages/Registration/components/UserAddress.tsx
+++ b/src/pages/Registration/components/UserAddress.tsx
@@ -1,14 +1,15 @@
 import { countriesOptions } from '@constants/countries.const';
-import { UserRegistrationData } from '@models/index';
 import { Stack, Typography } from '@mui/material';
 import { SelectElement, SwitchElement, TextFieldElement } from 'react-hook-form-mui';
+import { UserRegistrationData } from '@pages/Registration/components/RegistrationForm';
 
 export interface UserAddressProps {
   title: string;
   addressIndex: number;
+  onCountryChange?: (country: string) => void;
 }
 
-export function UserAddress({ title, addressIndex }: UserAddressProps) {
+export function UserAddress({ title, addressIndex, onCountryChange }: UserAddressProps) {
   return (
     <Stack>
       <Typography variant="h6" gutterBottom>
@@ -20,6 +21,7 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         options={countriesOptions}
         helperText=" "
         required
+        onChange={onCountryChange}
       />
       <TextFieldElement<UserRegistrationData>
         name={`addresses.${addressIndex}.postalCode`}
@@ -40,7 +42,6 @@ export function UserAddress({ title, addressIndex }: UserAddressProps) {
         helperText=" "
       />
       <SwitchElement<UserRegistrationData> label="set as default" name={`addresses.${addressIndex}.isDefault`} />
-      {/* {AsBillingButton} */}
     </Stack>
   );
 }


### PR DESCRIPTION
RSS-ECOMM-2_14 Set default addreses and RSS-ECOMM-2_15 Enable users to select different billing and shipping addresses

#### 🤔 This is a ...

- [x] 🌟 New task

#### Description
RSS-ECOMM-2_14
- [x]  Users can set a default address while registering. 🖱️
- [x] The setting of a default address happens simultaneously with user account creation. 🔄
- [x]  The default address is saved in the user profile upon successful registration. 💾
- [x]  Proper integration with the commercetools API for storing default address information. 🔗
- [x]  The user interface clearly distinguishes the default address selection during registration. 🔍

RSS-ECOMM-2_15
- [x] Users can enter separate addresses for billing and shipping during the registration process. 🛒
- [x] Users can choose to use the same address for both billing and shipping. ✅
- [x] The chosen addresses are saved in the user profile upon successful registration. 📥
- [x] The user interface clearly distinguishes between input fields for billing and shipping addresses. 📋
- [x] Proper integration with the commercetools API for storing billing and shipping address information. 🔗


#### Additional Information

![image](https://github.com/Maksim99745/eCommerce-Application/assets/137721533/929cf68f-d31e-4b69-98ca-98ac4b6e50fc)


#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
- [x] 👌 Have at least 1 approve.
- [x] 🌳 Branch from `develop`/`release/...` and target to `develop`/`release/...`.
