### PR TITLE
fix/RSS-ECOMM-2_28: change default address switch layout

### DIFF
--- a/src/pages/Registration/components/DefaultAddress.component.tsx
+++ b/src/pages/Registration/components/DefaultAddress.component.tsx
@@ -1,0 +1,17 @@
+import { RegistrationForm } from '@models/forms.model';
+import { Grid } from '@mui/material';
+import { SwitchElement } from 'react-hook-form-mui';
+
+export interface SwitchDefaultAddressProps {
+  title: string;
+  addressIndex: number;
+  disabled?: boolean;
+}
+
+export const DefaultAddress = ({ title, addressIndex, disabled = false }: SwitchDefaultAddressProps) => {
+  return (
+    <Grid item xs={1}>
+      <SwitchElement<RegistrationForm> label={title} name={`addresses.${addressIndex}.isDefault`} disabled={disabled} />
+    </Grid>
+  );
+};

--- a/src/pages/Registration/components/RegistrationForm.component.tsx
+++ b/src/pages/Registration/components/RegistrationForm.component.tsx
@@ -21,6 +21,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Container, Grid, Paper, Typography } from '@mui/material';
 import { registrationSchema } from '@core/validation/user-registration/user-registration.schema';
 import { UserAddressComponent } from './UserAddress.component';
+import { DefaultAddress } from './DefaultAddress.component';
 
 export interface RegistrationFormProps {
   onSubmit: (registrationData: RegistrationForm) => void;
@@ -135,6 +136,20 @@ export function RegistrationFormComponent({ onSubmit, isLoading }: RegistrationF
                   />
                 </Paper>
                 <Grid item>
+                  <DefaultAddress
+                    title="set as default shipping address"
+                    addressIndex={SHIPPING_ADDRESS_IDX}
+                    disabled={isLoading}
+                  />
+                </Grid>
+                {shippingAsBilling && (
+                  <DefaultAddress
+                    title="set as default billing address"
+                    addressIndex={BILLING_ADDRESS_IDX}
+                    disabled={isLoading}
+                  />
+                )}
+                <Grid item>
                   <CheckboxElement<RegistrationForm>
                     name="shippingAsBilling"
                     label="Use as billing address"
@@ -153,6 +168,11 @@ export function RegistrationFormComponent({ onSubmit, isLoading }: RegistrationF
                       disabled={isLoading}
                     />
                   </Paper>
+                  <DefaultAddress
+                    title="set as default billing address"
+                    addressIndex={BILLING_ADDRESS_IDX}
+                    disabled={isLoading}
+                  />
                 </Grid>
               )}
             </Grid>

--- a/src/pages/Registration/components/UserAddress.component.tsx
+++ b/src/pages/Registration/components/UserAddress.component.tsx
@@ -1,7 +1,7 @@
 import { countriesOptions } from '@core/validation/user-registration/user-registration.const';
 import { RegistrationForm } from '@models/forms.model';
 import { Stack, Typography } from '@mui/material';
-import { SelectElement, SwitchElement, TextFieldElement } from 'react-hook-form-mui';
+import { SelectElement, TextFieldElement } from 'react-hook-form-mui';
 
 export interface UserAddressProps {
   title: string;
@@ -51,12 +51,6 @@ export function UserAddressComponent({ title, addressIndex, onCountryChange, dis
         required
         helperText=" "
         InputLabelProps={{ shrink: true }}
-        disabled={disabled}
-      />
-
-      <SwitchElement<RegistrationForm>
-        label="set as default"
-        name={`addresses.${addressIndex}.isDefault`}
         disabled={disabled}
       />
     </Stack>

--- a/src/utils/map-form-to-customer-draft.ts
+++ b/src/utils/map-form-to-customer-draft.ts
@@ -27,6 +27,5 @@ export function mapFormToCustomerDraft(data: RegistrationForm): MyCustomerDraft 
     shippingAddresses: [SHIPPING_ADDRESS_IDX],
     billingAddresses: [data.shippingAsBilling ? SHIPPING_ADDRESS_IDX : BILLING_ADDRESS_IDX],
   };
-
   return Object.assign(draft, addressesIndices);
 }


### PR DESCRIPTION
fix/RSS-ECOMM-2_28: change default address switch layout

#### 🤔 This is a ...

- [x] 🛠 Fix in a task or related content

#### Description

I have implemented switches for the default address that appear based on whether the shipping address is used as the billing address. Additionally, the default address switch has been divided into separate components.

#### Additional Information

![image](https://github.com/Maksim99745/eCommerce-Application/assets/137721533/5f1b9d4a-ce8d-45e1-8a27-104c91659a13)

#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
- [ ] 👌 Have at least 1 approve.
- [x] 🌳 Branch from `develop`/`release/...` and target to `develop`/`release/...`.
